### PR TITLE
Fix Root drop down menu for Chrome

### DIFF
--- a/src/HopscotchForHTML5.ns
+++ b/src/HopscotchForHTML5.ns
@@ -314,11 +314,8 @@ createVisual ^ <Alien[Element]> = (
 		at: 'cursor' put: 'pointer'.
 	^column
 )
-removeContent ^ <Alien[Element]> = (
-	^visual removeChild: (visual at: 'lastChild')
-)
 toggleContent = (
-	menuActive ifTrue: [removeContent] ifFalse: [updateContent].
+	menuActive ifTrue: [(visual at: 'lastChild') blur] ifFalse: [updateContent].
 	menuActive:: menuActive not.
 )
 updateContent ^ <Alien[Element]> = (


### PR DESCRIPTION
In Chrome, there will be an event conflicting of `blur` and `click`, if
both of them are listening on.

This commit tries to fix this problem by triggering `blur` event when
handling `click`, to hand over menu contents removing task to `blur`
handler.

Steps to reproduce:

1. Open "Namespace" page in Chrome
2. Click "+" button beside "Root"
3. Select "Add Class"

Following exception will be occurred:

> Exception in turn without resolver
> Unhandled exception:
> Exception: NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?
> Exception class signal:
> Alien rawPerformCall:
> Alien perform:withArguments:
> Alien doesNotUnderstand: #removeChild:
> DropDownMenuFragment removeContent
> DropDownMenuFragment toggleContent
> [] in DropDownMenuFragment createVisual
> [] in Alien pushExpat:
> Message sendTo:
> [] in EventualSend deliver
> Closure on:do:
> EventualSend deliver
> InternalActor drainQueue
> MessageLoop drainQueue
> MessageLoop dispatchHandle:status:signals:count: