### PR TITLE
Fix references menu for Class Headers

### DIFF
--- a/src/Browsing.ns
+++ b/src/Browsing.ns
@@ -199,7 +199,7 @@ public messages = (
 	sent:: Array withAll: model selectors.
 	sent sort: [:a :b | lexicallyLessOrEqual: a than: b].
 	result addAll: sent.
-	result addAll: ((methodMirror metadata collect: [:ea | ea tag]) reject: [:ea | nil = ea]).
+	result addAll: ((model metadata collect: [:ea | ea tag]) reject: [:ea | nil = ea]).
 	^result
 )
 public name = (


### PR DESCRIPTION
This commit fixes an exception when clicking references menu for Class
Headers.

Reproduce:

1. Open "Namespace" page
2. Click "Collections"
3. Click "references" button of "usingInternalKernel:"

Following exception will be raised:

> Exception in turn without resolver
> Unhandled exception:
> MessageNotUnderstood: ClassHeaderSubject methodMirror
> ClassHeaderSubject(Object) doesNotUnderstand: #methodMirror
> ClassHeaderSubject messages
> [] in ClassHeaderPresenter(MemberPresenter) referencesMenu
> HopscotchForHTML5 computeContentForMenu:
> DropDownMenuFragment updateContent
> DropDownMenuFragment toggleContent
> [] in DropDownMenuFragment createVisual
> [] in Alien pushExpat:
> Message sendTo:
> [] in EventualSend deliver
> Closure on:do:
> EventualSend deliver
> InternalActor drainQueue
> MessageLoop drainQueue
> MessageLoop dispatchHandle:status:signals:count: