### PR TITLE
Several small tweaks to `build` script to make it non-platform specific

### DIFF
--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-source "$HOME/Applications/emsdk/emsdk_env.sh"
+[ -f "$HOME/Applications/emsdk/emsdk_env.sh" ] && source "$HOME/Applications/emsdk/emsdk_env.sh"
 cd primordialsoup
 ./build os=emscripten arch=wasm
 cd ..

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 source "$HOME/Applications/emsdk/emsdk_env.sh"
 cd primordialsoup

--- a/build
+++ b/build
@@ -16,12 +16,14 @@ cp CodeMirror/lib/codemirror.css out/CodeMirror/lib/codemirror_css.css
 cp CodeMirror/addon/display/autorefresh.js out/CodeMirror/addon/display/autorefresh.js
 cp src/* out
 
+ARCH=$(node -p "os.arch().toUpperCase()")
+
 cd out
-../primordialsoup/out/ReleaseARM64/primordialsoup \
+../primordialsoup/out/Release$ARCH/primordialsoup \
     ../primordialsoup/out/snapshots/CompilerApp.vfuel \
     *.ns \
     RuntimeWithMirrors WebCompiler WebCompiler.vfuel
-../primordialsoup/out/ReleaseARM64/primordialsoup \
+../primordialsoup/out/Release$ARCH/primordialsoup \
     WebCompiler.vfuel \
     *.ns \
     *.webp \


### PR DESCRIPTION
This PR contains several small tweaks to `build` script, to make it more portable to other platforms. Please see separate commit messages for more detail.

I have tested in following environments:

1. Ubuntu 22.04 X64 with system Emscription package 3.1.5
2. Debian 11 X64 with emsdk 3.1.13
3. Android 11 ARM64 (Termux) with system Emscription package 3.1.12