### PR TITLE
Fix WrappingParser for class header colorizer

### DIFF
--- a/src/CombinatorialParsing.ns
+++ b/src/CombinatorialParsing.ns
@@ -629,7 +629,7 @@ The output type of the wrapped parser, S, is also the input to the wrapper. The 
 class WrappingParser = CombinatorialParser (
 | parser wrapperBlock |) (
 public parse: input inContext: context ifError: blk = (
-	^wrapperBlock value: (parser parse: input inContext: context ifError: blk )
+	^wrapperBlock value: (parser parse: input inContext: context ifError: [:msg :pos | ^blk value: msg value: pos])
 )
 public wrapParser: p withWrapper: blk = (
 	parser:: p.

--- a/src/CombinatorialParsingTesting.ns
+++ b/src/CombinatorialParsingTesting.ns
@@ -1,0 +1,16 @@
+class CombinatorialParsingTesting usingCombinatorialParsing: c minitest: m = (|
+private TestContext = m TestContext.
+private ExecutableGrammar = c ExecutableGrammar.
+|) (
+public class WrappingParserTests = TestContext () (
+public testParseString = (
+	| p |
+	p:: ExecutableGrammar new whitespace wrap: [:_ | #wrap].
+	assert: (p parseString: ' ' ifError: [:_ :__ | #fail]) equals: #wrap.
+	assert: (p parseString: 'a' ifError: [:_ :__ | #fail]) equals: #fail.
+)
+) : (
+TEST_CONTEXT = ()
+)
+) : (
+)

--- a/src/CombinatorialParsingTestingConfiguration.ns
+++ b/src/CombinatorialParsingTestingConfiguration.ns
@@ -1,0 +1,9 @@
+class CombinatorialParsingTestingConfiguration packageTestsUsing: manifest = (|
+private CombinatorialParsing = manifest CombinatorialParsing.
+private CombinatorialParsingTesting = manifest CombinatorialParsingTesting.
+|) (
+public testModulesUsingPlatform: platform minitest: minitest = (
+	^{CombinatorialParsingTesting usingCombinatorialParsing: (CombinatorialParsing usingPlatform: platform) minitest: minitest}
+)
+) : (
+)


### PR DESCRIPTION
A MNU exception will raised when editing Class Header after adding Class.

This issue can be reproduced with following DoIt:

```
ide colorizer colorizeHeader: 'class' fromClass: nil via: [:range | ]
```

This commit tries to fix this issue by correct the wrong error handling of WrappingParser>>#parse:inContext:ifError: in CombinatorialParsing.