### PR TITLE
Fix colorization for temporaries

### DIFF
--- a/src/NewspeakColorization.ns
+++ b/src/NewspeakColorization.ns
@@ -306,7 +306,6 @@ class NS3Colorizer = TypedNS3Grammar (
 	braceDepth <Integer>
 	bracketDepth <Integer>
 	parenDepth <Integer>
-	isFirst ::= true.
 	mixinMirrorForObject <MixinMirror> = (ClassMirror reflecting: Object) mixin.
 |) (
 accessModifier = (
@@ -638,7 +637,6 @@ slotDef = (
 		[:tokens | | sd kind |
 		sd:: (tokens at: 2) first.
 		noteRange: #slotDecl from: sd start to: sd end.
-		(* isFirst ifTrue: [pushScope. isFirst: false]. *)
 		tokens]
 )
 slotName = (
@@ -673,23 +671,9 @@ symbolInScope: aString <String> ^ <Boolean> = (
 		(extendedCanUnderstand: aString) ifTrue: [^true].
 		^false
 )
-tempSlotDef = (
-	^super slotDef wrap: [ :tokens | | sd kind |
-		sd:: (tokens at: 2) first.
-		noteRange: #slotDecl from: sd start to: sd end.
-
-		isFirst ifTrue: [pushScope. isFirst: false].
-
-		kind:: (symbolInScope: sd value) ifTrue: [#shadowingTempVar] ifFalse: [#tempVar].
-		currentScope at: sd value put: #temporary.
-		currentScope at: sd value, ':' put: #temporary.
-		noteRange: kind from: sd start to: sd end.
-
-		tokens]
-)
 temporaries = (
 	|
-	tempSlotDefs = tempSlotDef star.
+	tempSlotDefs = slotDef star.
  	tempSeqSlotDecls = vbar, tempSlotDefs, vbar.
  	tempSimSlotDecls = vbar, vbar, tempSlotDefs, vbar, vbar.
  	tempSlotDecls = tempSimSlotDecls | tempSeqSlotDecls.
@@ -711,9 +695,18 @@ temporaries = (
 			vb3:: parts at: 4.
 			vb4:: parts at: 5].
 
-		isFirst: true.
 		noteRange: #methodTempBar from: vb1 start to: vb2 end.
 		noteRange: #methodTempBar from: vb3 start to: vb4 end.
+
+		pushScope.
+
+		vds do: [:tokens | | sd kind |
+			sd:: (tokens at: 2) first.
+			kind:: (symbolInScope: sd value) ifTrue: [#shadowingTempVar] ifFalse: [#tempVar].
+			currentScope at: sd value put: #temporary.
+			currentScope at: sd value, ':' put: #temporary.
+			noteRange: kind from: sd start to: sd end].
+
 		vds]
 )
 tupleType = (

--- a/src/NewspeakColorizationTesting.ns
+++ b/src/NewspeakColorizationTesting.ns
@@ -1,0 +1,16 @@
+class NewspeakColorizationTesting usingNewspeakColorization: c minitest: m = (|
+private TestContext = m TestContext.
+private NS3BrowserColorizer = c NS3BrowserColorizer.
+|) (
+public class NS3BrowserColorizerTests = TestContext (|
+private colorizer = NS3BrowserColorizer new.
+|) (
+public testParseDoIt = (
+	assert: (colorizer parseDoIt: '| foo' fromClass: nil) isKindOfTextBlock.
+	assert: (colorizer parseDoIt: '| foo' fromClass: nil) isKindOfTextBlock.
+)
+) : (
+TEST_CONTEXT = ()
+)
+) : (
+)

--- a/src/NewspeakColorizationTestingConfiguration.ns
+++ b/src/NewspeakColorizationTestingConfiguration.ns
@@ -1,0 +1,16 @@
+class NewspeakColorizationTestingConfiguration packageTestsUsing: manifest = (|
+private CombinatorialParsing = manifest CombinatorialParsing.
+private NewspeakGrammar = manifest NewspeakGrammar.
+private NewspeakColorization = manifest NewspeakColorization.
+private NewspeakColorizationTesting = manifest NewspeakColorizationTesting.
+|) (
+public testModulesUsingPlatform: platform minitest: minitest = (
+	|
+	parsing = CombinatorialParsing usingPlatform: platform.
+	grammar = NewspeakGrammar usingPlatform: platform parsers: parsing.
+	colorization = NewspeakColorization usingPlatform: platform grammar: grammar.
+	|
+	^{NewspeakColorizationTesting usingNewspeakColorization: colorization minitest: minitest}
+)
+) : (
+)


### PR DESCRIPTION
There will be a `Scope underflow` exception when typing temporaries declaration into Workspace.

It can be reproduced by following DoIt:

ide colorizer parseDoIt: '| foo' fromClass: nil

Copy code snippet into Workspace, and type Enter key for *two times*.

This issue is caused by inconsistent status of `isFirst` when parsing error is occurred. This commit tries to fix it by moving scope related operations to `temporaries`, so new scope will only be pushed if temporaries declaration is fully parsed with no error.

`isFirst` is not needed after this change.